### PR TITLE
fix: remove circular dependency of passing in context to something that is used in context

### DIFF
--- a/packages/logger/src/index.js
+++ b/packages/logger/src/index.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { ContextHelper, RestError } from '@adobe/content-lake-commons';
+import { RestError } from '@adobe/content-lake-commons';
 import { randomUUID } from 'crypto';
 
 export class OpsLog {
@@ -18,13 +18,12 @@ export class OpsLog {
 
   #logHeader;
 
-  constructor(context, jobId, requestId) {
+  constructor(log, jobId, requestId) {
     this.jobId = jobId;
     this.requestId = requestId;
     this.start = Date.now();
 
-    const contextHelper = new ContextHelper(context);
-    this.#log = contextHelper.getLog();
+    this.#log = log || console;
   }
 
   getLogHeader() {
@@ -107,7 +106,7 @@ export function logger(func) {
     const jobId = jobIdHeader || randomUUID();
     const requestIdHeader = params?.headers.get('x-request-id');
     const requestId = requestIdHeader || randomUUID();
-    const opsLog = new OpsLog(context, jobId, requestId);
+    const opsLog = new OpsLog(context?.log, jobId, requestId);
 
     context.log = opsLog;
     context.log.logStart();

--- a/packages/logger/test/index.test.js
+++ b/packages/logger/test/index.test.js
@@ -35,7 +35,7 @@ describe('OpsLog class', async () => {
   it('Create new OpsLog', () => {
     const jobId = randomUUID();
     const requestId = randomUUID();
-    const opsLog = new OpsLog(context, jobId, requestId);
+    const opsLog = new OpsLog(context.log, jobId, requestId);
     assert.strictEqual(opsLog.jobId, jobId);
     assert.strictEqual(opsLog.requestId, requestId);
     assert.strictEqual(opsLog.getLogHeader(), `JOB: ${jobId} REQ: ${requestId}`);
@@ -43,7 +43,7 @@ describe('OpsLog class', async () => {
   it('Add a step to the opsLog header', () => {
     const jobId = randomUUID();
     const requestId = randomUUID();
-    const opsLog = new OpsLog(context, jobId, requestId);
+    const opsLog = new OpsLog(context.log, jobId, requestId);
     opsLog.setStep('dispatch');
     assert.strictEqual(opsLog.jobId, jobId);
     assert.strictEqual(opsLog.requestId, requestId);
@@ -52,7 +52,7 @@ describe('OpsLog class', async () => {
   it('Check all log types work without an error', () => {
     const jobId = randomUUID();
     const requestId = randomUUID();
-    const opsLog = new OpsLog(context, jobId, requestId);
+    const opsLog = new OpsLog(context.log, jobId, requestId);
     assert.strictEqual(opsLog.getLogHeader(), `JOB: ${jobId} REQ: ${requestId}`);
 
     opsLog.error('error');
@@ -64,7 +64,7 @@ describe('OpsLog class', async () => {
   it('Trace not supported', () => {
     const jobId = randomUUID();
     const requestId = randomUUID();
-    const opsLog = new OpsLog(context, jobId, requestId);
+    const opsLog = new OpsLog(context.log, jobId, requestId);
     assert.strictEqual(opsLog.getLogHeader(), `JOB: ${jobId} REQ: ${requestId}`);
 
     try {


### PR DESCRIPTION
it was a circular dependency where `context` would be passed and used in `OpsLog` and `OpsLog` instance gets added to context.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
